### PR TITLE
Fixing a CURSOR block bug.

### DIFF
--- a/c-support/templates/c.preprocessor.template
+++ b/c-support/templates/c.preprocessor.template
@@ -36,16 +36,16 @@
 == ENDTEMPLATE ==
 
 §-------------------------------------------------------------------------
-== Preprocessor.include-global == map:pg, shortcut:g, insert ==
+== Preprocessor.include-global == map:pg, shortcut:g ==
 #include <<CURSOR>>
 §-------------------------------------------------------------------------
-== Preprocessor.include-local == map:pl, shortcut:l, insert ==
+== Preprocessor.include-local == map:pl, shortcut:l ==
 #include "<CURSOR>"
 §-------------------------------------------------------------------------
-== Preprocessor.define == map:pd, shortcut:d, insert ==
+== Preprocessor.define == map:pd, shortcut:d ==
 #define	<CURSOR>			/*  */
 §-------------------------------------------------------------------------
-== Preprocessor.undefine == map:pu, shortcut:u, insert ==
+== Preprocessor.undefine == map:pu, shortcut:u ==
 #undef	<CURSOR>			/*  */
 §-------------------------------------------------------------------------
 == Preprocessor.if-endif == map:pif, shortcut:i ==


### PR DESCRIPTION
CURSOR block does not disappear and is not functional with the modified templates. Removing the ", insert" from the template headers does fix this bug.
Picture of the bug: http://bayimg.com/hALBpaAfK
